### PR TITLE
Update folly build to temporarily use ahupp/folly

### DIFF
--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -11,10 +11,10 @@ vcpkg_add_to_path("${PYTHON3_DIR}")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO facebook/folly
-    REF 430aa0d8db79989dd56f8a0361fcb1c305618e41 # v2020.10.19.00
-    SHA512 d9f6aa0f7a8aee044c01af289d71e4c80d63e40ff128ac840663e3103d19cdd0da161a0b0d106493d950b9ac9a905c5e2abf8c1970c2f16b94dd95c0d1b1943e
-    HEAD_REF master
+    REPO ahupp/folly
+    HEAD_REF msvc-clang-cl
+    REF 1d843c45cd5466f655a1347d6e33480e1563425d
+    SHA512 6df52cc0f09b107b4de49ab93e90f5c02d7758b565897aeca87f37c4fd85e6a20fdf339029daf8c27cd8ff049ea846b1b22deea1d5657de78c483fa4444b588c
     PATCHES
         missing-include-atomic.patch
         reorder-glog-gflags.patch


### PR DESCRIPTION
Need to use a patched version of folly until https://github.com/facebook/folly/pull/1617 is accepted.